### PR TITLE
Support/override authorization header

### DIFF
--- a/.changeset/angry-crews-push.md
+++ b/.changeset/angry-crews-push.md
@@ -1,0 +1,12 @@
+---
+"@growi/sdk-typescript": patch
+---
+
+Add authorization header override functionality
+
+- Add `authorizationHeader` option to `AxiosInstanceManager.addAxiosInstance()`
+- Allow custom authorization headers instead of default Bearer token authentication
+- When `authorizationHeader` is specified, GROWI access token is sent via `X-GROWI-ACCESS-TOKEN` header
+- Support for Digest authentication, Basic authentication, and custom proxy authentication
+- Add detailed usage examples and documentation to README
+- Add comprehensive test cases covering error handling and edge cases

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ axiosInstanceManager.addAxiosInstance({
   baseURL: 'https://your-growi-instance-2.com',
   token: 'your-api-token-2',
 })
+
+// Example with Digest authentication when GROWI is behind Digest auth protection
+axiosInstanceManager.addAxiosInstance({  
+  name: 'app-3',
+  baseURL: 'https://your-growi-instance-3.com',
+  token: 'your-growi-access-token',
+  authorizationHeader: 'Digest username="user", realm="Protected Area", nonce="abc123", uri="/", response="xyz789"', // Digest auth header
+})
 ```
 
 ### API v3 Usage Example
@@ -126,6 +134,49 @@ src/
 
 - **API v3**: Contains new features and improved API endpoints. We recommend using v3 whenever possible.
 - **API v1**: Use when you need features not available in v3 or for legacy compatibility.
+
+### Authentication Header Override
+
+The SDK now supports overriding the default Bearer token authorization method. When the `authorizationHeader` option is provided:
+
+- The `Authorization` header will be set to the provided custom value
+- The GROWI access token will be sent via the `X-GROWI-ACCESS-TOKEN` header
+
+This feature is particularly useful when GROWI is behind authentication systems such as Digest authentication, Basic authentication, or custom proxy authentication that require specific authorization header formats.
+
+**Default behavior (Bearer token):**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'default-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'your-growi-api-token',
+  // Authorization header will be: "Bearer your-growi-api-token"
+});
+```
+
+**Digest authentication example:**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'digest-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'growi-api-token',
+  authorizationHeader: 'Digest username="admin", realm="GROWI Protected", nonce="abc123def456", uri="/", response="calculated-response-hash"',
+  // Authorization header will be set to the Digest auth string
+  // X-GROWI-ACCESS-TOKEN header will be: "growi-api-token"
+});
+```
+
+**Basic authentication example:**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'basic-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'growi-api-token',
+  authorizationHeader: 'Basic ' + btoa('username:password'),
+  // Authorization header will be: "Basic base64-encoded-credentials"
+  // X-GROWI-ACCESS-TOKEN header will be: "growi-api-token"
+});
+```
 
 ## Type Definition
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -59,6 +59,14 @@ axiosInstanceManager.addAxiosInstance({
   baseURL: 'https://your-growi-instance-2.com',
   token: 'your-api-token-2',
 })
+
+// GROWIがDigest認証で保護されている場合の例
+axiosInstanceManager.addAxiosInstance({  
+  name: 'app-3',
+  baseURL: 'https://your-growi-instance-3.com',
+  token: 'your-growi-access-token',
+  authorizationHeader: 'Digest username="user", realm="Protected Area", nonce="abc123", uri="/", response="xyz789"', // Digest認証ヘッダー
+})
 ```
 
 ### API v3 の使用例
@@ -126,6 +134,49 @@ src/
 
 - **API v3**: 新機能や改良された API エンドポイントが含まれています。可能な限り v3 の使用を推奨します。
 - **API v1**: v3 で提供されていない機能や、レガシー対応が必要な場合に使用してください。
+
+### 認証ヘッダーの上書き
+
+SDK は、デフォルトの Bearer トークン認証方法を上書きする機能をサポートしています。`authorizationHeader` オプションが提供された場合：
+
+- `Authorization` ヘッダーは提供されたカスタム値に設定されます
+- GROWI アクセストークンは `X-GROWI-ACCESS-TOKEN` ヘッダー経由で送信されます
+
+この機能は、特に GROWI が Digest認証、Basic認証、またはカスタムプロキシ認証などの認証システムの背後にある場合に、特定の認証ヘッダー形式が必要な時に便利です。
+
+**デフォルトの動作（Bearer トークン）:**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'default-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'your-growi-api-token',
+  // Authorization ヘッダーは: "Bearer your-growi-api-token" に設定されます
+});
+```
+
+**Digest認証の例:**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'digest-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'growi-api-token',
+  authorizationHeader: 'Digest username="admin", realm="GROWI Protected", nonce="abc123def456", uri="/", response="calculated-response-hash"',
+  // Authorization ヘッダーは Digest認証文字列に設定されます
+  // X-GROWI-ACCESS-TOKEN ヘッダーは: "growi-api-token" に設定されます
+});
+```
+
+**Basic認証の例:**
+```typescript
+axiosInstanceManager.addAxiosInstance({
+  name: 'basic-auth',
+  baseURL: 'https://growi.example.com',
+  token: 'growi-api-token',
+  authorizationHeader: 'Basic ' + btoa('username:password'),
+  // Authorization ヘッダーは: "Basic base64エンコードされた認証情報" に設定されます
+  // X-GROWI-ACCESS-TOKEN ヘッダーは: "growi-api-token" に設定されます
+});
+```
 
 ## 型定義
 

--- a/src/utils/axios-instance-manager.test.ts
+++ b/src/utils/axios-instance-manager.test.ts
@@ -1,0 +1,337 @@
+import type { AxiosInstance } from 'axios';
+import Axios from 'axios';
+import { type MockedFunction, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { axiosInstanceManager } from './axios-instance-manager.js';
+
+// Mock Axios
+vi.mock('axios');
+
+const mockedAxios = vi.mocked(Axios);
+
+describe('AxiosInstanceManager', () => {
+  let mockAxiosInstance: AxiosInstance;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock Axios instance
+    mockAxiosInstance = {
+      defaults: {
+        headers: {
+          common: {},
+          'X-GROWI-ACCESS-TOKEN': undefined,
+        },
+      },
+    } as unknown as AxiosInstance;
+
+    // Mock Axios.create to return our mock instance
+    mockedAxios.create = vi.fn().mockReturnValue(mockAxiosInstance);
+  });
+
+  afterEach(() => {
+    // Clear all instances after each test to ensure clean state
+    // Since we can't access the private instances directly, we'll test each scenario independently
+    vi.restoreAllMocks();
+  });
+
+  describe('addAxiosInstance', () => {
+    it('should create an Axios instance with correct baseURL', () => {
+      const config = {
+        appName: 'test-app',
+        baseURL: 'https://api.example.com',
+        token: 'test-token',
+      };
+
+      axiosInstanceManager.addAxiosInstance(config);
+
+      expect(mockedAxios.create).toHaveBeenCalledWith({
+        baseURL: 'https://api.example.com',
+      });
+    });
+
+    it('should set Bearer token authorization when authorizationHeader is undefined', () => {
+      const config = {
+        appName: 'test-app',
+        baseURL: 'https://api.example.com',
+        token: 'test-token-123',
+      };
+
+      axiosInstanceManager.addAxiosInstance(config);
+
+      expect(mockAxiosInstance.defaults.headers.common.Authorization).toBe('Bearer test-token-123');
+      expect(mockAxiosInstance.defaults.headers['X-GROWI-ACCESS-TOKEN']).toBeUndefined();
+    });
+
+    it('should set custom authorization header and GROWI access token when authorizationHeader is provided', () => {
+      const config = {
+        appName: 'test-app',
+        baseURL: 'https://api.example.com',
+        token: 'growi-token-456',
+        authorizationHeader: 'Custom custom-auth-value',
+      };
+
+      axiosInstanceManager.addAxiosInstance(config);
+
+      expect(mockAxiosInstance.defaults.headers.common.Authorization).toBe('Custom custom-auth-value');
+      expect(mockAxiosInstance.defaults.headers['X-GROWI-ACCESS-TOKEN']).toBe('growi-token-456');
+    });
+
+    it('should handle multiple instances with different names', () => {
+      const config1 = {
+        appName: 'app1',
+        baseURL: 'https://api1.example.com',
+        token: 'token1',
+      };
+
+      const config2 = {
+        appName: 'app2',
+        baseURL: 'https://api2.example.com',
+        token: 'token2',
+        authorizationHeader: 'Bearer custom-token',
+      };
+
+      // Create first instance
+      const mockInstance1 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      // Create second instance
+      const mockInstance2 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      (mockedAxios.create as MockedFunction<typeof Axios.create>).mockReturnValueOnce(mockInstance1).mockReturnValueOnce(mockInstance2);
+
+      axiosInstanceManager.addAxiosInstance(config1);
+      axiosInstanceManager.addAxiosInstance(config2);
+
+      expect(mockedAxios.create).toHaveBeenCalledTimes(2);
+      expect(mockedAxios.create).toHaveBeenNthCalledWith(1, { baseURL: 'https://api1.example.com' });
+      expect(mockedAxios.create).toHaveBeenNthCalledWith(2, { baseURL: 'https://api2.example.com' });
+
+      expect(mockInstance1.defaults.headers.common.Authorization).toBe('Bearer token1');
+      expect(mockInstance2.defaults.headers.common.Authorization).toBe('Bearer custom-token');
+      expect(mockInstance2.defaults.headers['X-GROWI-ACCESS-TOKEN']).toBe('token2');
+    });
+
+    it('should overwrite existing instance when using same appName', () => {
+      const config = {
+        appName: 'same-app',
+        baseURL: 'https://api.example.com',
+        token: 'original-token',
+      };
+
+      const updatedConfig = {
+        appName: 'same-app',
+        baseURL: 'https://api-updated.example.com',
+        token: 'updated-token',
+        authorizationHeader: 'Bearer updated-auth',
+      };
+
+      // Create first instance
+      const mockInstance1 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      // Create second instance
+      const mockInstance2 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      (mockedAxios.create as MockedFunction<typeof Axios.create>).mockReturnValueOnce(mockInstance1).mockReturnValueOnce(mockInstance2);
+
+      axiosInstanceManager.addAxiosInstance(config);
+      axiosInstanceManager.addAxiosInstance(updatedConfig);
+
+      expect(mockedAxios.create).toHaveBeenCalledTimes(2);
+      expect(mockedAxios.create).toHaveBeenNthCalledWith(2, { baseURL: 'https://api-updated.example.com' });
+
+      expect(mockInstance2.defaults.headers.common.Authorization).toBe('Bearer updated-auth');
+      expect(mockInstance2.defaults.headers['X-GROWI-ACCESS-TOKEN']).toBe('updated-token');
+    });
+
+    it('should handle edge cases with empty appName', () => {
+      const config = {
+        appName: '',
+        baseURL: 'https://api-v2.example.com',
+        token: 'updated-token',
+      };
+
+      expect(() => {
+        axiosInstanceManager.addAxiosInstance(config);
+      }).toThrow('appName must be a non-empty string');
+    });
+
+    it('should handle edge cases with empty baseURL', () => {
+      const config = {
+        appName: 'app-name',
+        baseURL: '',
+        token: 'updated-token',
+      };
+
+      expect(() => {
+        axiosInstanceManager.addAxiosInstance(config);
+      }).toThrow('baseURL must be a non-empty string');
+    });
+
+    it('should handle edge cases with empty token', () => {
+      const config = {
+        appName: 'app-name',
+        baseURL: 'https://api.example.com',
+        token: '',
+      };
+
+      expect(() => {
+        axiosInstanceManager.addAxiosInstance(config);
+      }).toThrow('token must be a non-empty string');
+    });
+  });
+
+  describe('getAxiosInstance', () => {
+    it('should return the correct instance for a valid appName', () => {
+      const config = {
+        appName: 'valid-app',
+        baseURL: 'https://api.example.com',
+        token: 'test-token',
+      };
+
+      axiosInstanceManager.addAxiosInstance(config);
+      const instance = axiosInstanceManager.getAxiosInstance('valid-app');
+
+      expect(instance).toBe(mockAxiosInstance);
+    });
+
+    it('should throw an error for non-existent appName', () => {
+      expect(() => {
+        axiosInstanceManager.getAxiosInstance('non-existent-app');
+      }).toThrow('No Axios instance found for appName: non-existent-app');
+    });
+
+    it('should throw an error with correct message format', () => {
+      const invalidAppName = 'invalid-app-name-123';
+
+      expect(() => {
+        axiosInstanceManager.getAxiosInstance(invalidAppName);
+      }).toThrow(`No Axios instance found for appName: ${invalidAppName}`);
+    });
+
+    it('should return different instances for different appNames', () => {
+      const config1 = {
+        appName: 'app1',
+        baseURL: 'https://api1.example.com',
+        token: 'token1',
+      };
+
+      const config2 = {
+        appName: 'app2',
+        baseURL: 'https://api2.example.com',
+        token: 'token2',
+      };
+
+      const mockInstance1 = {
+        id: 'instance1',
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+      const mockInstance2 = {
+        id: 'instance2',
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      (mockedAxios.create as MockedFunction<typeof Axios.create>).mockReturnValueOnce(mockInstance1).mockReturnValueOnce(mockInstance2);
+
+      axiosInstanceManager.addAxiosInstance(config1);
+      axiosInstanceManager.addAxiosInstance(config2);
+
+      const instance1 = axiosInstanceManager.getAxiosInstance('app1');
+      const instance2 = axiosInstanceManager.getAxiosInstance('app2');
+
+      expect(instance1).toBe(mockInstance1);
+      expect(instance2).toBe(mockInstance2);
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('integration tests', () => {
+    it('should correctly manage the complete lifecycle of instances', () => {
+      // Add first instance
+      const config1 = {
+        appName: 'lifecycle-app',
+        baseURL: 'https://api.example.com',
+        token: 'initial-token',
+      };
+
+      const mockInstance1 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      (mockedAxios.create as MockedFunction<typeof Axios.create>).mockReturnValueOnce(mockInstance1);
+
+      axiosInstanceManager.addAxiosInstance(config1);
+      let instance = axiosInstanceManager.getAxiosInstance('lifecycle-app');
+
+      expect(instance).toBe(mockInstance1);
+      expect(instance.defaults.headers.common.Authorization).toBe('Bearer initial-token');
+
+      // Update the same instance
+      const config2 = {
+        appName: 'lifecycle-app',
+        baseURL: 'https://api-v2.example.com',
+        token: 'updated-token',
+        authorizationHeader: 'Custom auth-header',
+      };
+
+      const mockInstance2 = {
+        defaults: {
+          headers: {
+            common: {},
+            'X-GROWI-ACCESS-TOKEN': undefined,
+          },
+        },
+      } as unknown as AxiosInstance;
+
+      (mockedAxios.create as MockedFunction<typeof Axios.create>).mockReturnValueOnce(mockInstance2);
+
+      axiosInstanceManager.addAxiosInstance(config2);
+      instance = axiosInstanceManager.getAxiosInstance('lifecycle-app');
+
+      expect(instance).toBe(mockInstance2);
+      expect(instance.defaults.headers.common.Authorization).toBe('Custom auth-header');
+      expect(instance.defaults.headers['X-GROWI-ACCESS-TOKEN']).toBe('updated-token');
+    });
+  });
+});

--- a/src/utils/axios-instance-manager.ts
+++ b/src/utils/axios-instance-manager.ts
@@ -11,13 +11,18 @@ class AxiosInstanceManager {
    * @param appName The name/key for the instance.
    * @param config The configuration for the Axios instance.
    */
-  addAxiosInstance(config: { appName: string; baseURL: string; token: string }) {
+  addAxiosInstance(config: { appName: string; baseURL: string; token: string; authorizationHeader: string | undefined }) {
     const axiosInstance = Axios.create({
       baseURL: config.baseURL,
     });
 
     // Set the Authorization header
+    if (config.authorizationHeader) {
+      axiosInstance.defaults.headers.common.Authorization = config.authorizationHeader;
+      axiosInstance.defaults.headers['X-GROWI-ACCESS-TOKEN'] = config.token;
+    } else {
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${config.token}`;
+    }
 
     this.instances.set(config.appName, axiosInstance);
   }

--- a/src/utils/axios-instance-manager.ts
+++ b/src/utils/axios-instance-manager.ts
@@ -11,7 +11,7 @@ class AxiosInstanceManager {
    * @param appName The name/key for the instance.
    * @param config The configuration for the Axios instance.
    */
-  addAxiosInstance(config: { appName: string; baseURL: string; token: string; authorizationHeader: string | undefined }) {
+  addAxiosInstance(config: { appName: string; baseURL: string; token: string; authorizationHeader?: string | undefined }) {
     if (config.appName.length === 0) throw new Error('appName must be a non-empty string');
     if (config.baseURL.length === 0) throw new Error('baseURL must be a non-empty string');
     if (config.token.length === 0) throw new Error('token must be a non-empty string');

--- a/src/utils/axios-instance-manager.ts
+++ b/src/utils/axios-instance-manager.ts
@@ -12,6 +12,10 @@ class AxiosInstanceManager {
    * @param config The configuration for the Axios instance.
    */
   addAxiosInstance(config: { appName: string; baseURL: string; token: string; authorizationHeader: string | undefined }) {
+    if (config.appName.length === 0) throw new Error('appName must be a non-empty string');
+    if (config.baseURL.length === 0) throw new Error('baseURL must be a non-empty string');
+    if (config.token.length === 0) throw new Error('token must be a non-empty string');
+
     const axiosInstance = Axios.create({
       baseURL: config.baseURL,
     });
@@ -21,7 +25,7 @@ class AxiosInstanceManager {
       axiosInstance.defaults.headers.common.Authorization = config.authorizationHeader;
       axiosInstance.defaults.headers['X-GROWI-ACCESS-TOKEN'] = config.token;
     } else {
-    axiosInstance.defaults.headers.common.Authorization = `Bearer ${config.token}`;
+      axiosInstance.defaults.headers.common.Authorization = `Bearer ${config.token}`;
     }
 
     this.instances.set(config.appName, axiosInstance);


### PR DESCRIPTION
This pull request adds support for custom authorization headers in the `@growi/sdk-typescript` package, allowing users to override the default Bearer token authentication. This is particularly useful for environments where GROWI is protected by Digest authentication, Basic authentication, or custom proxy authentication. The changes include updates to documentation (in both English and Japanese), comprehensive test coverage, and additional input validation in the `AxiosInstanceManager`.

**Authorization header override and authentication improvements:**

* Added an `authorizationHeader` option to `AxiosInstanceManager.addAxiosInstance()`, allowing users to specify custom authorization headers instead of the default Bearer token. When provided, the GROWI access token is sent via the `X-GROWI-ACCESS-TOKEN` header, supporting Digest, Basic, and custom authentication schemes. [[1]](diffhunk://#diff-e127cf9bbcd4a733702c7113387f8233dbb75a05feafe52472092ae2e839a47bL14-R29) [[2]](diffhunk://#diff-7593661a8eb27d14c099aa9d5b48d808d83760349b7938701561f42657344a01R1-R12)

**Documentation updates:**

* Updated `README.md` and `README_JP.md` with detailed explanations and usage examples for the new `authorizationHeader` functionality, including code samples for Bearer, Digest, and Basic authentication scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138-R180) [[3]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25R62-R69) [[4]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25R138-R180)

**Testing and validation:**

* Added comprehensive test cases in `axios-instance-manager.test.ts` to cover the new functionality, including edge cases and error handling for invalid input.
* Implemented input validation in `addAxiosInstance` to ensure `appName`, `baseURL`, and `token` are non-empty strings, throwing descriptive errors for invalid input.