### PR TITLE
fix(build): use nodenext moduleResolution to unblock the release build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Problem

The release workflow's `publish` step (`release-sdk:publish` → `pnpm build` → `tsc -p tsconfig.build.json`) is failing, so `@growi/sdk-typescript@1.9.0` was bumped/committed but **never published to npm** (npm latest is still `1.8.0`, no `v1.9.0` tag).

```
tsconfig.build.json(4): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

### Root cause

`typescript` is **not a direct dependency** — it is only pulled in transitively (lockfile resolves `5.8.3`). CI runs `pnpm install` (non-frozen) and floated `tsc` to **TypeScript 6.0.3**, which turns the long-standing `moduleResolution: "node"` (node10) into a **hard error**. This would break *any* release, not just this one; the changeset merge merely triggered the release that exercised it.

## Fix

Switch the build to `module` / `moduleResolution: "nodenext"` — the correct setting for this published Node ESM package (every relative import already carries a `.js` extension, so nodenext resolves cleanly). This drops the deprecated `node10` option entirely, so the build no longer depends on the TypeScript version.

## Why this is safe (verified, not assumed)

Built the project on **both** TypeScript `5.8.3` and `6.0.3`, comparing the emitted `dist/` at the same output depth:

| Comparison | Result |
|---|---|
| old `node10` @ 5.8.3 (what previous releases shipped) vs new `nodenext` @ 6.0.3 (what CI will ship) | **byte-identical, including sourcemaps** ✅ |
| `nodenext` build on TS 5.8.3 | exit 0 |
| `nodenext` build on TS 6.0.3 (CI) | exit 0 |
| base typecheck (`tsconfig.json`, unchanged) | exit 0 |
| `pnpm lint` | clean |

`moduleResolution` does not affect JS/`.d.ts` emit, so consumers receive exactly the same artifacts. (For reference, `moduleResolution: "bundler"` was rejected because it rewrites `.d.ts` type-import paths through the re-export barrel — `nodenext` does not.)

**No changeset** is included: `tsconfig.build.json` is not part of the published package (`files` = dist/src/README/CHANGELOG/LICENSE) and the emit is unchanged, so this is a tooling-only fix with no consumer-facing change and should not bump the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)